### PR TITLE
Minor changes for compatibility with cfs-manager-gui

### DIFF
--- a/cfs_manager/cfs_watcher.py
+++ b/cfs_manager/cfs_watcher.py
@@ -1,10 +1,10 @@
 import os
 from cfs_manager import zipper
 
-def main():
+def main(dir_to_watch=os.getcwd()):
     location = os.path.split(os.path.abspath(zipper.__file__))[0]
     in_managed = False
-    currdir = str(os.getcwd())
+    currdir = str(dir_to_watch)
 
     try:
         with open(os.path.join(location, 'managed.txt'), 'r') as managed:
@@ -16,7 +16,7 @@ def main():
 
     if not in_managed:
         with open(os.path.join(location, 'managed.txt'), 'a') as managed:
-            line = '\n' + str(os.getcwd())
+            line = '\n' + str(dir_to_watch)
             managed.write(line)
 
         with open('zipper.ignore', 'w') as ignore:

--- a/cfs_manager/cli.py
+++ b/cfs_manager/cli.py
@@ -1,5 +1,6 @@
 import re, os, sys, shutil
 sys.path.insert(0, os.path.split(os.path.abspath(__file__))[0])  #Set the sys path to the current dir before importing local packages
+os.chdir(os.path.split(os.path.abspath(__file__))[0])  #Set the working dir to the current dir before importing local packages
 from help_functions import *  # * import because help_functions is explicitly designed not to overload the namespace
 from manager import Main_FS
 

--- a/cfs_manager/manager.py
+++ b/cfs_manager/manager.py
@@ -1,4 +1,4 @@
-import os, sys, shutil
+import os, shutil
 from file_systems import CloudFileSystem, PCloud_FS, GDrive_FS, DBox_FS, _Box_FS
 from file_systems import download_move
 

--- a/cfs_manager/manager.py
+++ b/cfs_manager/manager.py
@@ -1,5 +1,4 @@
 import os, sys, shutil
-os.chdir(os.path.split(os.path.abspath(__file__))[0])  #Set the working dir to the current dir before importing local packages
 from file_systems import CloudFileSystem, PCloud_FS, GDrive_FS, DBox_FS, _Box_FS
 from file_systems import download_move
 
@@ -245,11 +244,13 @@ class Main_FS(CloudFileSystem):
                 new_file_location = None
         return new_file_location
 
-    def inspect_file(self, filename):
+    def inspect_file(self, filename, return_dict=False):
         for f in self.files:
             if f['filename'] == filename+'.zip':
                 file_dict = f
                 break
+        if return_dict:
+            return file_dict
         info = []
         for key in file_dict:
             statement = str(key) +" :  "+ str(file_dict[key])


### PR DESCRIPTION
None of these changes impact the behavior of cfs-manager.

cfs_watcher.py was modified to optionally watch a folder outside of the cwd.

The code to change the current directory was moved back from manager.py to cli.py. (Originally it was moved to manager.py on my request, but this turned out not to be necessary.)

Finally, the inspect_file method in manager.py was modified to optionally return a dictionary of info about the file instead of a list of strings.